### PR TITLE
Add dotenv config and example env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# Environment variables for the Grocery Store app
+# Provide your Stripe secret key below
+STRIPE_SECRET_KEY=
+
+# Session secret used to sign cookies
+SESSION_SECRET=grocery-secret

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ web_modules/
 
 # dotenv environment variable files
 .env
+!.env
 .env.development.local
 .env.test.local
 .env.production.local

--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ Start the server:
 npm start
 ```
 
-Before starting, set environment variables for Stripe payments and sessions:
+Before starting, create a `.env` file in the project root. Place your Stripe
+secret key in this file and set a session secret key. A template is provided and
+already committed to the repository:
 
 ```bash
-export STRIPE_SECRET_KEY=your_stripe_secret_key
-export SESSION_SECRET=your_session_secret
+cp .env .env.local  # optionally create a local copy
+```
+
+Edit `.env` (or `.env.local`) and fill in the following values:
+
+```ini
+STRIPE_SECRET_KEY=your_stripe_secret_key
+SESSION_SECRET=grocery-secret
 ```
 
 The application will create a SQLite file `db.sqlite` to store user accounts on first run.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const session = require('express-session');
 const bcrypt = require('bcrypt');
 const sqlite3 = require('sqlite3').verbose();
 const Stripe = require('stripe');
+require('dotenv').config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.0",
+        "dotenv": "^17.0.1",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "express-session": "^1.17.3",
@@ -555,6 +556,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.1.tgz",
+      "integrity": "sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcrypt": "^5.1.0",
+    "dotenv": "^17.0.1",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "express-session": "^1.17.3",
     "sqlite3": "^5.1.6",
-    "bcrypt": "^5.1.0",
     "stripe": "^12.15.0"
   }
 }


### PR DESCRIPTION
## Summary
- set up `dotenv` to load environment variables
- include `.env` with placeholders for session and Stripe keys
- document environment variable setup in README
- allow `.env` to be committed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68667bfbd374832a9af4dc5edd79927d